### PR TITLE
Corrected branch name on created packages.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,13 +12,16 @@ build_tar:
   script:
     - DESCRIBE=$(git describe)
     - echo ${DESCRIBE} >> describe
+    - BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    - echo ${BRANCH} >> branch
     - npm install && npm install
     - ./node_modules/gulp/bin/gulp.js release
-    - tar -czf aremi-natmap-${CI_BUILD_REF_NAME}-${DESCRIBE}.tar.gz serverconfig.json package.json node_modules wwwroot && echo
+    - tar -czf aremi-natmap-${BRANCH}-${DESCRIBE}.tar.gz serverconfig.json package.json node_modules wwwroot && echo
   artifacts:
     paths:
-      - "aremi-natmap-${CI_BUILD_REF_NAME}-*.tar.gz"
+      - "aremi-natmap-*.tar.gz"
       - describe
+      - branch
 
 upload_tar:
   image: etd-docker01.it.csiro.au/nay019/aremi-s3-uploader
@@ -28,9 +31,10 @@ upload_tar:
   stage: upload_tar
   script:
     - DESCRIBE=$(cat ./describe)
+    - BRANCH=$(cat ./branch)
     - aws configure set aws_access_key_id ${access_key}
     - aws configure set aws_secret_access_key ${secret_key}
-    - aws s3 cp aremi-natmap-${CI_BUILD_REF_NAME}-${DESCRIBE}.tar.gz s3://aremi-ci-apps/aremi-natmap-${CI_BUILD_REF_NAME}-${DESCRIBE}.tar.gz
+    - aws s3 cp aremi-natmap-${BRANCH}-${DESCRIBE}.tar.gz s3://aremi-ci-apps/aremi-natmap-${BRANCH}-${DESCRIBE}.tar.gz
 
 trigger_ami_build:
   image: etd-docker01.it.csiro.au/nay019/aremi-ami-builder
@@ -40,6 +44,8 @@ trigger_ami_build:
   stage: trigger_ami_build
   script:
     - DESCRIBE=$(cat ./describe)
-    - TAR=aremi-natmap-${CI_BUILD_REF_NAME}-${DESCRIBE}.tar.gz
+    - BRANCH=$(cat ./branch)
+    - TAR=aremi-natmap-${BRANCH}-${DESCRIBE}.tar.gz
     - curl -s -X POST -F token=${aremi_cloud_token} -F ref=master -F variables[tar]=${TAR} -F variables[access_key]=${access_key} -F variables[secret_key]=${secret_key} "https://data61.githost.io/api/v3/projects/39/trigger/builds" > /dev/null
     - echo "Triggered a build on another repository. Check https://data61.githost.io/TerriaJS/aremi-cloud/pipelines to find the build. Logs will continue there."
+


### PR DESCRIPTION
`${CI_BUILD_REF_NAME}` was returning tag name when building with tags resulting in names like `aremi-natmap-2017-02-22-2017-02-22.tar.gz`

Reverted to getting branch name the same way that make_package does.