### PR TITLE
[#114] Solar Climatology Datasets: Change from parameters.colorscalerange to colorScaleMinimum/colorScaleMaximum.

### DIFF
--- a/datasources/aremi/custodian/Bureau_of_Meteorology/Solar_Climatology.ejs
+++ b/datasources/aremi/custodian/Bureau_of_Meteorology/Solar_Climatology.ejs
@@ -8,9 +8,9 @@
     "currentTime":"mmmm",
     "timelineTic":"dd/mmm"
   },
-  "parameters": {
-    "colorscalerange": "3.5,31"
-  },
+  "supportsColorScaleRange": "true",
+  "colorScaleMinimum": "3.5",
+  "colorScaleMaximum": "31",
   "featureInfoTemplate" : {
     "template": "{{#value}}{{value}} MJ/m&#178;{{/value}}",
     "name": "{{#value}}{{value}} MJ/m2{{/value}}"
@@ -28,9 +28,9 @@
     "currentTime":"mmmm",
     "timelineTic":"dd/mmm"
   },
-  "parameters": {
-    "colorscalerange": "3.5,34"
-  },
+  "supportsColorScaleRange": "true",
+  "colorScaleMinimum": "3.5",
+  "colorScaleMaximum": "34",
   "featureInfoTemplate" : {
     "template": "{{#value}}{{value}} MJ/m&#178;{{/value}}",
     "name": "{{#value}}{{value}} MJ/m2{{/value}}"
@@ -44,9 +44,9 @@
   "layers": "mean_exposure",
   "url": "http://neii.bom.gov.au/services/solarclim/wms/data/annClim_gloHorExp1Day.nc",
   "type": "wms",
-  "parameters": {
-    "colorscalerange": "11,23.5"
-  },
+  "supportsColorScaleRange": "true",
+  "colorScaleMinimum": "11",
+  "colorScaleMaximum": "23.5",
   "featureInfoTemplate" : {
     "template": "{{#value}}{{value}} MJ/m&#178;{{/value}}",
     "name": "{{#value}}{{value}} MJ/m2{{/value}}"
@@ -60,9 +60,9 @@
   "layers": "mean_exposure",
   "url": "http://neii.bom.gov.au/services/solarclim/wms/data/annClim_dirNorExp1Day.nc",
   "type": "wms",
-  "parameters": {
-    "colorscalerange": "9.5,27.5"
-  },
+  "supportsColorScaleRange": "true",
+  "colorScaleMinimum": "9.5",
+  "colorScaleMaximum": "27.5",
   "featureInfoTemplate" : {
     "template": "{{#value}}{{value}} MJ/m&#178;{{/value}}",
     "name": "{{#value}}{{value}} MJ/m2{{/value}}"


### PR DESCRIPTION
Submitting this as a PR so that you can view the colour ranges before merging.

Note: That I determined via trial and error that current bounds on the **monthly** data currently are actually:
```
-  "colorScaleMinimum": "3.5",
+  "colorScaleMinimum": "17",

-  "colorScaleMinimum": "3.5",
+  "colorScaleMinimum": "10",
```
but given that it is winter I would assume that the previously used values might actually be more accurate even though at the moment they result in there being less variability in the colour presently.

One outstanding question, is there a reason why the colour ranges are not the same for the different series? seems like it might make a more sensible default so that if people are comparing that at least for the same data type they can directly compare by default (and they can always tweak if they want to from there).

Also it seems that the colour range might be the inverse of what would be desirable since given that the monthly data minimums are the values that need to be lifted to give the full colour range and that it is currently winter I would assume that higher values might actually mean less exposure? Or is something else going on here?