### PR TITLE
use #08abd5 as main branding color

### DIFF
--- a/lib/Styles/variables.scss
+++ b/lib/Styles/variables.scss
@@ -6,6 +6,7 @@
 // If your logo is big, set this to give it more room.
 $logo-height: 130px;
 
+$color-primary: $turquoise-blue;
 /*
 // If using a non-standard font, remember to include an @import statement in global.scss
 $font-base: 'Josefin Sans', sans-serif;


### PR DESCRIPTION
Fix https://github.com/TerriaJS/aremi-natmap/issues/365

However, this will make aremi main branding color different from that of the nationalmap. This might not be desirable. 