### PR TITLE
Fix invalid json in regionmapping

### DIFF
--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -1490,12 +1490,12 @@
                 ],
                 [
                     "^6$",
-                    "Northern Territory"
+                    "Northern Territory",
                     "Tasmania"
                 ],
                 [
                     "^7$",
-                    "Australian Capital Territory"
+                    "Australian Capital Territory",
                     "Northern Territory"
                 ],
                 [

--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -1490,12 +1490,10 @@
                 ],
                 [
                     "^6$",
-                    "Northern Territory",
                     "Tasmania"
                 ],
                 [
                     "^7$",
-                    "Australian Capital Territory",
                     "Northern Territory"
                 ],
                 [
@@ -2096,14 +2094,18 @@
                 ],
                 [
                     "^6$",
-                    "Northern Territory"
+                    "Tasmania"
                 ],
                 [
                     "^7$",
-                    "Australian Capital Territory"
+                    "Northern Territory"
                 ],
                 [
                     "^8$",
+                    "Australian Capital Territory"
+                ],
+                [
+                    "^9$",
                     "Other Territories"
                 ]
             ],


### PR DESCRIPTION
Missing a couple of comma's, introduced in https://github.com/TerriaJS/aremi-natmap/pull/403/commits/88f2ce4e104ad1c4abe62709a0344a943e404753